### PR TITLE
Weaponry rebalance

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/antimateriel.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/antimateriel.yml
@@ -7,7 +7,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 40
+        Piercing: 30
         Structural: 30
   - type: StaminaDamageOnCollide
     damage: 35

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/caseless_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/caseless_rifle.yml
@@ -7,7 +7,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 19
+        Piercing: 11
 
 - type: entity
   id: BulletCaselessRiflePractice

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/heavy_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/heavy_rifle.yml
@@ -7,7 +7,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 19
+        Piercing: 10
 
 - type: entity
   id: BulletMinigun

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/light_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/light_rifle.yml
@@ -7,7 +7,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 19
+        Piercing: 10
 
 - type: entity
   id: BulletLightRiflePractice
@@ -30,7 +30,7 @@
     damage:
       types:
         Blunt: 3
-        Heat: 16
+        Heat: 9
 
 - type: entity
   id: BulletLightRifleUranium
@@ -41,5 +41,5 @@
   - type: Projectile
     damage:
       types:
-        Radiation: 9
-        Piercing: 10
+        Radiation: 7
+        Piercing: 3

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/magnum.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/magnum.yml
@@ -7,7 +7,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 35
+        Piercing: 20
 
 - type: entity
   id: BulletMagnumPractice
@@ -30,7 +30,7 @@
     damage:
       types:
         Blunt: 3
-        Heat: 32
+        Heat: 15
 
 - type: entity
   id: BulletMagnumAP
@@ -41,7 +41,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 26 # 20% decrease
+        Piercing: 20 # 20% decrease
     ignoreResistances: true
 
 - type: entity
@@ -53,5 +53,5 @@
   - type: Projectile
     damage:
       types:
-        Radiation: 15
-        Piercing: 20
+        Radiation: 8
+        Piercing: 10

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/pistol.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/pistol.yml
@@ -7,7 +7,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 16
+        Piercing: 9
 
 - type: entity
   id: BulletPistolPractice
@@ -30,7 +30,7 @@
     damage:
       types:
         Blunt: 2
-        Heat: 14
+        Heat: 9
 
 - type: entity
   id: BulletPistolUranium
@@ -42,4 +42,4 @@
     damage:
       types:
         Radiation: 6
-        Piercing: 10
+        Piercing: 5

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/rifle.yml
@@ -7,7 +7,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 17
+        Piercing: 9
 
 - type: entity
   id: BulletRiflePractice
@@ -30,7 +30,7 @@
     damage:
       types:
         Blunt: 2
-        Heat: 15
+        Heat: 9
 
 - type: entity
   id: BulletRifleUranium
@@ -42,5 +42,5 @@
     damage:
       types:
         Radiation: 7
-        Piercing: 8
+        Piercing: 4
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
@@ -10,7 +10,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 28
+        Piercing: 18
 
 - type: entity
   id: PelletShotgunBeanbag
@@ -24,7 +24,7 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 10
+        Blunt: 4
   - type: StaminaDamageOnCollide
     damage: 40 # 3 hits to stun
 
@@ -40,7 +40,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 10
+        Piercing: 6
 
 - type: entity
   id: PelletShotgunSpread
@@ -64,8 +64,8 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 3
-        Heat: 7
+        Blunt: 2
+        Heat: 4
   - type: IgnitionSource
     ignited: true
 
@@ -115,8 +115,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 3
-        Slash: 3
+        Piercing: 2
+        Slash: 2
 
 - type: entity
   id: PelletShotgunImprovisedSpread
@@ -214,8 +214,8 @@
   - type: Projectile
     damage:
       types:
-        Radiation: 5
-        Piercing: 5
+        Radiation: 3
+        Piercing: 2
 
 - type: entity
   id: PelletShotgunUraniumSpread
@@ -242,7 +242,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 25
+        Piercing: 12
         Structural: 5
 
 - type: entity
@@ -273,7 +273,7 @@
     deleteOnCollide: false
     damage:
       types:
-        Slash: 25
+        Slash: 12
 
 - type: entity
   id: PelletGlassSpread

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -60,7 +60,7 @@
     impactEffect: BulletImpactEffect
     damage:
       types:
-        Piercing: 14
+        Piercing: 9
     soundHit:
       path: /Audio/Weapons/Guns/Hits/bullet_hit.ogg
   - type: TimedDespawn
@@ -113,14 +113,14 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 14
+        Blunt: 7
   - type: PointLight
     enabled: true
     color: "#ff4300"
     radius: 2.0
     energy: 7.0
   - type: IgniteOnCollide
-    fireStacks: 0.25
+    fireStacks: 0.15
 
 - type: entity
   id: BaseBulletAP
@@ -135,7 +135,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 11 # 20% decrease
+        Piercing: 7 # 20% decrease
     ignoreResistances: true
 
 - type: entity
@@ -151,7 +151,7 @@
   - type: Projectile
     damage:
       types:
-        Radiation: 11
+        Radiation: 7
 
 # Energy projectiles
 - type: entity


### PR DESCRIPTION


## About the PR
Режет урон всему огнестрелу. 

## Why / Balance
На станциии огнестрел будет очень легок в получении и доступен. Поэтому стоит порезать его урон, т.к баланс билда будет склонен скорее к лазерам. 

